### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ permalink: index.html
 
  LibDoc is a Jekyll theme that was crafted to easily and quickly get properly designed documentation especially for CSS and Javascript libraries. It comes with a [built-in playground](https://olivier3lanc.github.io/Jekyll-LibDoc/libdoc-playground.html) and local search engine.
 
-![LibDoc layout](assets/libdoc/img/libdoc-layout-page-split.webp)
+![LibDoc layout](https://github.com/olivier3lanc/Jekyll-LibDoc/raw/master/assets/libdoc/img/libdoc-layout-page-split.webp)
 
 ## Showcase
 
@@ -65,7 +65,7 @@ Your repository is now ready to be deployed as GitHub Pages website, all you hav
 
 ### Online - No installation copy or clone
 
-![Github.dev](assets/libdoc/img/libdoc-edit-online.webp)
+![Github.dev](https://github.com/olivier3lanc/Jekyll-LibDoc/raw/master/assets/libdoc/img/libdoc-edit-online.webp)
 
 It is possible to craft documentation with LibDoc only with your browser, [Github](https://www.github.com) and [Github Pages](https://pages.github.com). 
 


### PR DESCRIPTION
Absolute image URLs help in case of jekyll-themes.com to display the images in the theme page https://jekyll-themes.com/jekyll-libdoc/